### PR TITLE
remove width 'fit-content' in .project-link

### DIFF
--- a/themes/jeo-theme/assets/scss/5-pages/_p-single.scss
+++ b/themes/jeo-theme/assets/scss/5-pages/_p-single.scss
@@ -977,7 +977,7 @@
                 justify-content: center;
                 align-items: center;
                 padding: 18px 51px;
-                width: fit-content;
+                /* width: fit-content; not compatible with Safari*/
                 border-radius: 10px;
                 text-transform: uppercase;
                 font-weight: bold;


### PR DESCRIPTION
- [x] Fix project button's appearance in Project Page in Safari / Mac

This rule: ` width: fit-content ` is not compatible with Safari
![image](https://user-images.githubusercontent.com/12487823/95902719-8a6d1b00-0d6b-11eb-9071-3b529d19a3eb.png)

In Chrome
![image](https://user-images.githubusercontent.com/12487823/96864487-e0625280-143e-11eb-874a-c96ff89412cc.png)
