### PR TITLE
fix 'authors-listing' instead of 'author-bio-display

### DIFF
--- a/themes/jeo-theme/template-parts/header/entry-header.php
+++ b/themes/jeo-theme/template-parts/header/entry-header.php
@@ -48,7 +48,7 @@ if (!get_query_var('model') || get_query_var('model') !== 'video') :
 			<!-- publishers -->
 				
 			<div class="entry-meta">
-				<?php if (get_post_meta(get_the_ID(), 'author-bio-display', true) && empty( $terms )) : ?>
+				<?php if (get_post_meta(get_the_ID(), 'authors-listing', true) && empty( $terms )) : ?>
 					<?php newspack_posted_by(); ?>
 				<?php endif; ?>
 				<div></div>

--- a/themes/jeo-theme/template-parts/singles/single-opinion.php
+++ b/themes/jeo-theme/template-parts/singles/single-opinion.php
@@ -17,7 +17,7 @@
 					?>
 				<!-- publishers -->
                 <div class="entry-meta">
-                    <?php if (get_post_meta(get_the_ID(), 'author-bio-display', true)) : ?>
+                    <?php if (get_post_meta(get_the_ID(), 'authors-listing', true)) : ?>
                         <?php newspack_posted_by(); ?>
                     <?php endif; ?>
                     <div></div>

--- a/themes/jeo-theme/template-parts/singles/single-project.php
+++ b/themes/jeo-theme/template-parts/singles/single-project.php
@@ -17,7 +17,7 @@
         <div class="main-content">
             <div class="entry-subhead">
                 <div class="entry-meta">
-                    <?php if (get_post_meta(get_the_ID(), 'author-bio-display', true)) : ?>
+                    <?php if (get_post_meta(get_the_ID(), 'authors-listing', true)) : ?>
                         <?php newspack_posted_by(); ?>
                     <?php endif; ?>
                     <div></div>

--- a/themes/jeo-theme/template-parts/singles/single-video.php
+++ b/themes/jeo-theme/template-parts/singles/single-video.php
@@ -27,7 +27,7 @@
                 <?php if (!is_page() && 'behind' !== newspack_featured_image_position() && !get_query_var('hide_post_meta')) : ?>
                     <div class="entry-subhead">
                         <div class="entry-meta">
-                            <?php if (get_post_meta(get_the_ID(), 'author-bio-display', true)) : ?>
+                            <?php if (get_post_meta(get_the_ID(), 'authors-listing', true)) : ?>
                                 <?php newspack_posted_by(); ?>
                             <?php endif; ?>
                             <?php newspack_posted_on(); ?>
@@ -48,7 +48,7 @@
 					?>
 					<!-- publishers -->
                     <div class="entry-meta">
-                        <?php if (get_post_meta(get_the_ID(), 'author-bio-display', true)) : ?>
+                        <?php if (get_post_meta(get_the_ID(), 'authors-listing', true)) : ?>
                             <?php newspack_posted_by(); ?>
                         <?php endif; ?>
                         <div></div>


### PR DESCRIPTION
**Case 1**
In a new post
![image](https://user-images.githubusercontent.com/12487823/98398346-97fe8380-203f-11eb-9d61-7c009fb8704d.png)

![image](https://user-images.githubusercontent.com/12487823/98398364-a056be80-203f-11eb-93a0-9dcf725c8d7a.png)


**Case 2**
![image](https://user-images.githubusercontent.com/12487823/98399181-ccbf0a80-2040-11eb-82be-d1eed88f37a5.png)

![image](https://user-images.githubusercontent.com/12487823/98399226-da749000-2040-11eb-922b-9a0f384668cc.png)


Bug
In some templates, we were using 'author-bio-display' instead of 'authors-listing"
![image](https://user-images.githubusercontent.com/12487823/98535094-500c7600-2264-11eb-9749-ca874adbc39c.png)
