### PR TITLE
refs[#409] remove 'no media partner', add placeholder in original pub…

### DIFF
--- a/themes/jeo-theme/functions.php
+++ b/themes/jeo-theme/functions.php
@@ -286,7 +286,7 @@ function show_publishers($id){
 }
 
 function get_publisher($id){
-	$partner_name = 'No media partner';
+	$partner_name = '';
 	if(taxonomy_exists('partner')){
 		$partners = get_the_terms( $id, 'partner');
 		if ($partners && count($partners) > 0){

--- a/themes/jeo-theme/inc/metaboxes.php
+++ b/themes/jeo-theme/inc/metaboxes.php
@@ -92,7 +92,7 @@ function project_link_callback() {
 		<p>
 			<div class="jeo-row-content">
 				<label for="project-link">
-					<input placeholder="Requires https://" style="width: 100%" type="text" name="project-link" id="project-link" value="<?php if (isset($jeo_stored_meta['project-link'])) echo $jeo_stored_meta['project-link'][0]; ?>"  />
+					<input placeholder="Requires https:// or http//" style="width: 100%" type="text" name="project-link" id="project-link" value="<?php if (isset($jeo_stored_meta['project-link'])) echo $jeo_stored_meta['project-link'][0]; ?>"  />
 				</label>
 			</div>
 		</p>
@@ -216,7 +216,7 @@ function twitter_opinion_video_callback() {
 			<span class="jeo-row-title"><?php _e('Video URL to be shown on twitter sharing preview: ', 'jeo') ?></span>
 			<div class="jeo-row-content">
 				<label for="twitter-opinion-video">
-					<input placeholder="Requires https://" type="text" name="twitter-opinion-video" id="twitter-opinion-video" value="<?php if (isset($jeo_stored_meta['twitter-opinion-video'])) echo $jeo_stored_meta['twitter-opinion-video'][0]; ?>"  />
+					<input placeholder="Requires https:// or http//" type="text" name="twitter-opinion-video" id="twitter-opinion-video" value="<?php if (isset($jeo_stored_meta['twitter-opinion-video'])) echo $jeo_stored_meta['twitter-opinion-video'][0]; ?>"  />
 				</label>
 			</div>
 		</p>
@@ -280,7 +280,7 @@ function display_external_post_callback() {
 			<br><br>
 			<label for="external-source-link">
 				<?php _e('Original Publisher link', 'jeo') ?>
-				<input type="text" style="width: 100%" name="external-source-link" id="external-source-link" value="<?php if (isset($jeo_stored_meta['external-source-link'])) echo $jeo_stored_meta['external-source-link'][0]; ?>" />
+				<input placeholder="Requires https:// or http//"  type="text" style="width: 100%" name="external-source-link" id="external-source-link" value="<?php if (isset($jeo_stored_meta['external-source-link'])) echo $jeo_stored_meta['external-source-link'][0]; ?>" />
 			</label>
 
 		</div>


### PR DESCRIPTION
- [x] Remove 'no media partner'
**Teste 1:**
- Criar um post
- Não selecionar media partner
- Preencher o campo "original publisher link"
- Publicar o post. Aparece só o ícone do link

![image](https://user-images.githubusercontent.com/12487823/104525398-d33ca600-55de-11eb-8a4f-051b9a9624e8.png)

![image](https://user-images.githubusercontent.com/12487823/104525338-b011f680-55de-11eb-804c-7cf568689311.png)

**Teste 2:**
- Criar um post com Media Partner e "original publisher link", só para conferir que continua funcionando 

![image](https://user-images.githubusercontent.com/12487823/104526241-b2755000-55e0-11eb-9177-c6f4624b4950.png)


- [x] Só falta colocar o "Requires https:// or http://" em cinza como os demais campos semelhantes na área de edição do post.

![image](https://user-images.githubusercontent.com/12487823/104521942-adae9d00-55dc-11eb-8578-61315f31160c.png)
