### PR TITLE
Apply customized secondary colors

### DIFF
--- a/themes/jeo-theme/assets/scss/1-settings/_s-globals.scss
+++ b/themes/jeo-theme/assets/scss/1-settings/_s-globals.scss
@@ -6,7 +6,7 @@
 
 .entry-content a {
     text-decoration: none !important;
-    
+
     &:hover {
         font-weight: bold;
     }
@@ -14,11 +14,11 @@
 
 a {
     text-decoration: none !important;
-    
+
     &:hover {
         font-weight: bold;
     }
-    
+
     &:focus {
         outline: 0px;
     }
@@ -40,7 +40,7 @@ body {
     h2.article-section-title {
         font-size: size(18) !important;
     }
-    
+
     p {
         line-height: 20px;
     }
@@ -71,7 +71,7 @@ body {
         position: relative;
         display: block;
         height: 0;
-        
+
         img {
             height: 100%;
             width: 100%;
@@ -83,7 +83,7 @@ body {
             bottom: 0;
         }
     }
-    
+
 }
 
 .wp-block-newspack-blocks-homepage-articles {
@@ -188,6 +188,20 @@ body {
 .entry .entry-content .is-style-outline .wp-block-button__link.has-primary-color:not(:hover),
 .entry .entry-content .wp-block-button__link.is-style-outline.has-primary-color:not(:hover) {
   color: var(--primary);
+}
+
+entry .entry-content .has-secondary-background-color,
+.entry .entry-content .wp-block-pullquote.is-style-solid-color.has-secondary-background-color {
+    background-color: var(--secondary);
+}
+
+.entry .entry-content .has-secondary-color,
+.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color,
+.entry .entry-content .wp-block-pullquote.is-style-solid-color blockquote.has-secondary-color p,
+.entry .entry-content .wp-block-button.has-secondary-color,
+.entry .entry-content .is-style-outline .wp-block-button__link.has-secondary-color:not(:hover),
+.entry .entry-content .wp-block-button__link.is-style-outline.has-secondary-color:not(:hover) {
+    color: var(--secondary);
 }
 
 
@@ -314,7 +328,7 @@ body {
 }
 
 @include tablet {
-    
+
     .col-md-6,
     .col-sm-3,
     .col-sm-9,
@@ -322,7 +336,7 @@ body {
         flex: 0 0 100%;
         max-width: 100%;
     }
-    
+
     .search .col-md-10 {
         padding-right: 0px;
         padding-left: 0px;
@@ -347,7 +361,7 @@ body {
     .d-lg-block {
         display: block !important;
     }
-    
+
     .d-lg-none {
         display: none !important;
     }
@@ -357,7 +371,7 @@ body {
     .d-md-block {
         display: block !important;
     }
-    
+
     .d-md-none {
         display: none !important;
     }
@@ -454,19 +468,19 @@ input[type='submit']:focus {
                 background-size: 33%;
             }
         }
-        
+
         &.category-map {
             figure.post-thumbnail a:after {
                 background-image: url("data:image/svg+xml,%3Csvg aria-hidden='true' focusable='false' data-prefix='far' data-icon='map' role='img' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 576 512' class='svg-inline--fa fa-map fa-w-18 fa-3x'%3E%3Cpath fill='white' d='M560.02 32c-1.96 0-3.98.37-5.96 1.16L384.01 96H384L212 35.28A64.252 64.252 0 0 0 191.76 32c-6.69 0-13.37 1.05-19.81 3.14L20.12 87.95A32.006 32.006 0 0 0 0 117.66v346.32C0 473.17 7.53 480 15.99 480c1.96 0 3.97-.37 5.96-1.16L192 416l172 60.71a63.98 63.98 0 0 0 40.05.15l151.83-52.81A31.996 31.996 0 0 0 576 394.34V48.02c0-9.19-7.53-16.02-15.98-16.02zM224 90.42l128 45.19v285.97l-128-45.19V90.42zM48 418.05V129.07l128-44.53v286.2l-.64.23L48 418.05zm480-35.13l-128 44.53V141.26l.64-.24L528 93.95v288.97z' class=''%3E%3C/path%3E%3C/svg%3E");
             }
         }
-        
+
         &.category-video {
             figure.post-thumbnail a:after {
                 background-image: url("data:image/svg+xml,%3Csvg aria-hidden='true' focusable='false' data-prefix='fas' data-icon='play' class='svg-inline--fa fa-play fa-w-14' role='img' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 448 512'%3E%3Cpath fill='white' d='M424.4 214.7L72.4 6.6C43.8-10.3 0 6.1 0 47.9V464c0 37.5 40.7 60.1 72.4 41.3l352-208c31.4-18.5 31.5-64.1 0-82.6z'%3E%3C/path%3E%3C/svg%3E");
             }
         }
-        
+
         &.category-audio {
             figure.post-thumbnail a:after {
                 background-image: url("data:image/svg+xml,%3Csvg aria-hidden='true' focusable='false' data-prefix='fas' data-icon='headphones' role='img' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 512 512' class='svg-inline--fa fa-headphones fa-w-16 fa-3x'%3E%3Cpath fill='white' d='M256 32C114.52 32 0 146.496 0 288v48a32 32 0 0 0 17.689 28.622l14.383 7.191C34.083 431.903 83.421 480 144 480h24c13.255 0 24-10.745 24-24V280c0-13.255-10.745-24-24-24h-24c-31.342 0-59.671 12.879-80 33.627V288c0-105.869 86.131-192 192-192s192 86.131 192 192v1.627C427.671 268.879 399.342 256 368 256h-24c-13.255 0-24 10.745-24 24v176c0 13.255 10.745 24 24 24h24c60.579 0 109.917-48.098 111.928-108.187l14.382-7.191A32 32 0 0 0 512 336v-48c0-141.479-114.496-256-256-256z' class=''%3E%3C/path%3E%3C/svg%3E");

--- a/themes/jeo-theme/assets/scss/1-settings/_s-globals.scss
+++ b/themes/jeo-theme/assets/scss/1-settings/_s-globals.scss
@@ -190,7 +190,7 @@ body {
   color: var(--primary);
 }
 
-entry .entry-content .has-secondary-background-color,
+.entry .entry-content .has-secondary-background-color,
 .entry .entry-content .wp-block-pullquote.is-style-solid-color.has-secondary-background-color {
     background-color: var(--secondary);
 }


### PR DESCRIPTION
Currently, we override Newspack's primary color via `var(--primary)`, but secondary color is hardcoded as `#555` (Newspack's default). This adds an override via `var(--secondary)`.

References hacklabr/plenamata#109.